### PR TITLE
Fix for switching to a branch not (yet) on the server

### DIFF
--- a/lib/branch-status.coffee
+++ b/lib/branch-status.coffee
@@ -133,10 +133,14 @@ pollStatus = ->
     else if state
       branchElement.css color: "pink"
       console.error state, message
+    else
+      branchElement.css color: "inherit"
+      message = null
+
+    # Remove any previous tool tip
+    tooltip?.dispose()
 
     if message
-      # Remove previous tool tip
-      tooltip?.dispose()
       # Show status message in tool tip
       tooltip = atom.tooltips.add(branchElement, {title: message})
 
@@ -146,6 +150,11 @@ pollStatus = ->
       link = $("<a class='branch-status-target-link'>" + labelElement[0].innerText + "</a>")
       link.on "click", -> Shell.openExternal(targetUrl)
       labelElement.html(link)
+    else
+      # Remove any previous link
+      labelElement = $('.git-branch .branch-label')
+      text = $("<span>" + labelElement[0].innerText + "</span>")
+      labelElement.html(text)
 
 module.exports =
   config:


### PR DESCRIPTION
The branch status was showing weird stuff if the branch is not (yet) pushed to the server:
![screenshot from 2015-06-11 23 13 17](https://cloud.githubusercontent.com/assets/3522333/8118925/9d5ee118-109a-11e5-90d8-3e91b6f635d4.png)

This happened if you first were on a branch that had a status and then switched to a new branch (or any other ref that doesn't have a status).

This is now fixed and everything returns to boring old grey, if the server doesn't return a status for the ref.